### PR TITLE
Return score along with best segmentation

### DIFF
--- a/instant-segment-py/src/lib.rs
+++ b/instant-segment-py/src/lib.rs
@@ -89,12 +89,14 @@ impl Segmenter {
     /// The `search` object contains buffers used for searching. When the search completes,
     /// iterate over the `Search` to get the resulting words.
     ///
+    /// On success, returns the score of the sentence found.
+    ///
     /// For best performance, reusing `Search` objects is recommended.
-    fn segment(&self, s: &str, search: &mut Search) -> PyResult<()> {
+    fn segment(&self, s: &str, search: &mut Search) -> PyResult<f64> {
         match self.inner.segment(s, &mut search.inner) {
-            Ok(_) => {
+            Ok((_words, score)) => {
                 search.cur = Some(0);
-                Ok(())
+                Ok(score)
             }
             Err(_) => Err(PyValueError::new_err(
                 "only lowercase ASCII letters allowed",

--- a/instant-segment-py/test/test.py
+++ b/instant-segment-py/test/test.py
@@ -16,7 +16,8 @@ def bigrams():
 def main():
     segmenter = instant_segment.Segmenter(unigrams(), bigrams())
     search = instant_segment.Search()
-    segmenter.segment('thisisatest', search)
+    score = segmenter.segment('thisisatest', search)
+    print(f"{score=}")
     print([word for word in search])
 
 if __name__ == '__main__':

--- a/instant-segment/examples/contrived.rs
+++ b/instant-segment/examples/contrived.rs
@@ -18,7 +18,7 @@ fn main() {
     let segmenter = Segmenter::new(unigrams, bigrams);
     let mut search = Search::default();
 
-    let words = segmenter.segment("choosespain", &mut search).unwrap();
+    let (words, _score) = segmenter.segment("choosespain", &mut search).unwrap();
 
     println!("{:?}", words.collect::<Vec<&str>>());
 }

--- a/instant-segment/src/lib.rs
+++ b/instant-segment/src/lib.rs
@@ -251,7 +251,7 @@ impl<'a> Ascii<'a> {
     }
 }
 
-impl<'a> Index<Range<usize>> for Ascii<'a> {
+impl Index<Range<usize>> for Ascii<'_> {
     type Output = str;
 
     fn index(&self, index: Range<usize>) -> &Self::Output {

--- a/instant-segment/src/test_cases.rs
+++ b/instant-segment/src/test_cases.rs
@@ -3,7 +3,11 @@ use crate::{Search, Segmenter};
 /// Run a segmenter against the built-in test cases
 pub fn run(segmenter: &Segmenter) {
     let mut search = Search::default();
-    assert_eq!(segmenter.segment("", &mut search).unwrap().len(), 0);
+    {
+        let (words, score) = segmenter.segment("", &mut search).unwrap();
+        assert_eq!(words.len(), 0);
+        assert_eq!(score, 0.0);
+    }
 
     let mut success = true;
     for test in TEST_CASES.iter().copied() {
@@ -18,7 +22,7 @@ pub fn run(segmenter: &Segmenter) {
 }
 
 pub fn assert_segments(s: &[&str], search: &mut Search, segmenter: &Segmenter) -> bool {
-    let words = segmenter.segment(&s.join(""), search).unwrap();
+    let (words, _score) = segmenter.segment(&s.join(""), search).unwrap();
     let cmp = words.collect::<Vec<_>>();
     let success = cmp == s;
     if !success {
@@ -30,7 +34,7 @@ pub fn assert_segments(s: &[&str], search: &mut Search, segmenter: &Segmenter) -
 
 pub fn check_segments(s: &[&str], search: &mut Search, segmenter: &Segmenter) -> bool {
     match segmenter.segment(&s.join(""), search) {
-        Ok(words) => s == words.collect::<Vec<_>>(),
+        Ok((words, _score)) => s == words.collect::<Vec<_>>(),
         Err(_) => false,
     }
 }


### PR DESCRIPTION
Have `segment()` return the score that it obtained, as well as the sentence.

Currently I find myself writing code that goes
```rust
let words = segmenter.segment(&text, &mut search).unwrap();
let score = segmenter.score_sentence(words).unwrap();
```
which is quite inefficient since the segmenter knew the score that it got all along.

Caution: obviously this is a breaking API change on the rust side.  But I think it is a very natural one.